### PR TITLE
PREP-73: Allow anonymous users to move to the next step in a workflow…

### DIFF
--- a/workflow.php
+++ b/workflow.php
@@ -317,3 +317,10 @@ function workflow_workflow_getStepParams(&$step, $workflowId) {
     default:
   }
 }
+
+/**
+ * Implements hook_civicrm_alterAPIPermissions
+ */
+function workflow_civicrm_alterAPIPermissions($entity, $action, &$params, &$permissions) {
+  $permissions['workflow']['complete_step'] = array('access ajax api');
+}


### PR DESCRIPTION
… (provided they have the 'acces ajax api' permission.
